### PR TITLE
Ensure the 'shape' field of LWPOLYLINE is boolean

### DIFF
--- a/lib/DxfParser.js
+++ b/lib/DxfParser.js
@@ -1071,7 +1071,7 @@ DxfParser.prototype._parse = function(dxfString) {
 					curr = scanner.next();
 					break;
 				case 70: // 1 = Closed shape, 128 = plinegen?, 0 = default
-					entity.shape = (curr.value & 1 === 1);
+					entity.shape = ((curr.value & 1) === 1);
 					curr = scanner.next();
 					break;
 				case 90:


### PR DESCRIPTION
Unit tests are failing because the 'shape' field of a LWPOLYLINE is
expected to be a boolean, but is an integer.

Commit 1b00a3027dcec02b39170c9086a1dc5447b234ec misuse some operators
(operator '&' has a lower precendence than operator '==='),
causing (curr.value & 1 === 1) to be parsed as (curr.value & (1 === 1)).

This patch add parenthesis to make sure the '1' flag of curr.value is
properly tested.