### PR TITLE
Handel entity 3DFace

### DIFF
--- a/lib/DxfParser.js
+++ b/lib/DxfParser.js
@@ -616,9 +616,9 @@ DxfParser.prototype._parse = function(dxfString) {
 					entity = parseLINE();
 					log.debug('}');
 				 } else if (curr.value === '3DFACE') {
-                    log.debug('3DFACE {');
-                    entity = parse3DFACE();
-                    log.debug('}');
+					log.debug('3DFACE {');
+					entity = parse3DFACE();
+					log.debug('}');
 				} else if(curr.value === 'CIRCLE') {
 					log.debug('CIRCLE {');
 					entity = parseCIRCLE();
@@ -1066,7 +1066,7 @@ DxfParser.prototype._parse = function(dxfString) {
             i;
         var vertexIsStarted = false;
         var vertexIsFinished = false;
-		var verticesPer3dFace = 4; // there can be up to four vertices per face, although 3 is most used for TIN
+        var verticesPer3dFace = 4; // there can be up to four vertices per face, although 3 is most used for TIN
 		
         for (i = 0; i <= verticesPer3dFace; i++) {
             var vertex = {};
@@ -1077,7 +1077,7 @@ DxfParser.prototype._parse = function(dxfString) {
                     case 10: // X0
                     case 11: // X1
                     case 12: // X2
-					case 13: // X3
+                    case 13: // X3
                         if (vertexIsStarted) {
                             vertexIsFinished = true;
                             continue;
@@ -1088,13 +1088,13 @@ DxfParser.prototype._parse = function(dxfString) {
                     case 20: // Y
                     case 21:
                     case 22:
-					case 23:
+                    case 23:
                         vertex.y = curr.value;
                         break;
                     case 30: // Z
                     case 31:
                     case 32:
-					case 33:
+                    case 33:
                         vertex.z = curr.value;
                         break;
                     default:
@@ -1135,7 +1135,6 @@ DxfParser.prototype._parse = function(dxfString) {
                     break;
                 default:
                     checkCommonEntityProperties(entity);
-					// curr = scanner.next();
                     break;
             }
         }

--- a/lib/DxfParser.js
+++ b/lib/DxfParser.js
@@ -615,6 +615,10 @@ DxfParser.prototype._parse = function(dxfString) {
 					log.debug('LINE {');
 					entity = parseLINE();
 					log.debug('}');
+				 } else if (curr.value === '3DFACE') {
+                    log.debug('3DFACE {');
+                    entity = parse3DFACE();
+                    log.debug('}');
 				} else if(curr.value === 'CIRCLE') {
 					log.debug('CIRCLE {');
 					entity = parseCIRCLE();
@@ -1056,6 +1060,87 @@ DxfParser.prototype._parse = function(dxfString) {
 
 		return entity;
 	};
+	
+	var parse3dFaceVertices = function(entity) {
+        var vertices = [],
+            i;
+        var vertexIsStarted = false;
+        var vertexIsFinished = false;
+		var verticesPer3dFace = 4; // there can be up to four vertices per face, although 3 is most used for TIN
+		
+        for (i = 0; i <= verticesPer3dFace; i++) {
+            var vertex = {};
+            while (curr !== 'EOF') {
+                if (curr.code === 0 || vertexIsFinished) break;
+
+                switch (curr.code) {
+                    case 10: // X0
+                    case 11: // X1
+                    case 12: // X2
+					case 13: // X3
+                        if (vertexIsStarted) {
+                            vertexIsFinished = true;
+                            continue;
+                        }
+                        vertex.x = curr.value;
+                        vertexIsStarted = true;
+                        break;
+                    case 20: // Y
+                    case 21:
+                    case 22:
+					case 23:
+                        vertex.y = curr.value;
+                        break;
+                    case 30: // Z
+                    case 31:
+                    case 32:
+					case 33:
+                        vertex.z = curr.value;
+                        break;
+                    default:
+                        // it is possible to have entity codes after the vertices.  
+                        // So if code is not accounted for return to entity parser where it might be accounted for
+                        return vertices;
+                        continue;
+                }
+                curr = scanner.next();
+            }
+            // See https://groups.google.com/forum/#!topic/comp.cad.autocad/9gn8s5O_w6E
+            vertices.push(vertex);
+            vertexIsStarted = false;
+            vertexIsFinished = false;
+        }
+        return vertices;
+    };
+
+    /**
+     * Called when the parser reads the beginning of a new entity,
+     * 0:parse3DFACE. Scanner.next() will return the first attribute of the
+     * entity.
+     * @return {Object} the entity parsed
+     */
+    var parse3DFACE = function() {
+        var entity = { type: curr.value, vertices: [] };
+          curr = scanner.next();
+        while (curr !== 'EOF') {
+            if (curr.code === 0) break;
+            switch (curr.code) {
+                case 70: // 1 = Closed shape, 128 = plinegen?, 0 = default
+                    entity.shape = ((curr.value & 1) === 1);
+                    entity.hasContinuousLinetypePattern = ((curr.value & 128) === 128);
+                    curr = scanner.next();
+                    break;
+                case 10: // X coordinate of point
+                    entity.vertices = parse3dFaceVertices();
+                    break;
+                default:
+                    checkCommonEntityProperties(entity);
+					// curr = scanner.next();
+                    break;
+            }
+        }
+        return entity;
+    };
 
 	/**
 	 * Called when the parser reads the beginning of a new entity,


### PR DESCRIPTION
added function to support 3dFace and 3dfacevertices.  Styled after lwpolyline function except number of vertices is already known as 3 or 4 for a face, faces uses 10,20,30 but also 11,21,31, 12,22,32, and 13,23,33