### PR TITLE
Proposal to improve ATTDEF

### DIFF
--- a/lib/entities/attdef.js
+++ b/lib/entities/attdef.js
@@ -37,9 +37,6 @@ EntityParser.prototype.parseEntity = function(scanner, curr) {
             case 11: // X coordinate of 'second alignment point'
                 entity.endPoint = helpers.parsePoint(scanner);
                 break;
-            case 30:
-                entity.z = curr.value;
-                break;
             case 39:
                 entity.thickness = curr.value;
                 break;

--- a/lib/entities/attdef.js
+++ b/lib/entities/attdef.js
@@ -31,11 +31,11 @@ EntityParser.prototype.parseEntity = function(scanner, curr) {
             case 7:
                 entity.textStyle = curr.value;
                 break;
-            case 10:
-                entity.x = curr.value;
+            case 10: // X coordinate of 'first alignment point'
+                entity.startPoint = helpers.parsePoint(scanner);
                 break;
-            case 20:
-                entity.y = curr.value;
+            case 11: // X coordinate of 'second alignment point'
+                entity.endPoint = helpers.parsePoint(scanner);
                 break;
             case 30:
                 entity.z = curr.value;

--- a/test/data/blocks.expected.json
+++ b/test/data/blocks.expected.json
@@ -131,12 +131,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.2580357142857142,
-          "y": -0.1201923076923079,
-          "z": 0,
+          "startPoint": {
+            "x": -0.2580357142857142,
+            "y": -0.1201923076923079,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": -0.0733173076923079,
+            "z": 0
+          },
           "prompt": "Sheet Number?",
           "tag": "SHEETNO",
           "invisible": false,
@@ -154,12 +161,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.1821428571428571,
-          "y": 0.0264423076923075,
-          "z": 0,
+          "startPoint": {
+            "x": -0.1821428571428571,
+            "y": 0.0264423076923075,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": 0.0733173076923075,
+            "z": 0
+          },
           "prompt": "Detail Number?",
           "tag": "DETNO",
           "invisible": false,
@@ -777,13 +791,20 @@
           "handle": "E46",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 15.97514981098344,
-          "y": 2.753495907230559,
-          "z": 0,
+          "startPoint": {
+            "x": 15.97514981098344,
+            "y": 2.753495907230559,
+            "z": 0
+          },
           "textHeight": 0.125,
           "text": "City, State",
           "rotation": 90,
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.97514981098344,
+            "y": 3.15625,
+            "z": 0
+          },
           "prompt": "Project Loction",
           "tag": "PROJECTLOCATION",
           "invisible": false,
@@ -798,13 +819,20 @@
           "handle": "E47",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 15.77434831030132,
-          "y": 2.695301841746248,
-          "z": 0,
+          "startPoint": {
+            "x": 15.77434831030132,
+            "y": 2.695301841746248,
+            "z": 0
+          },
           "textHeight": 0.125,
           "text": "Project Title",
           "rotation": 90,
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.77434831030132,
+            "y": 3.15625,
+            "z": 0
+          },
           "prompt": "Project Title Line 2",
           "tag": "PROJECTTITLE2",
           "invisible": false,
@@ -819,13 +847,20 @@
           "handle": "E48",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 15.57354680961919,
-          "y": 2.695301841746248,
-          "z": 0,
+          "startPoint": {
+            "x": 15.57354680961919,
+            "y": 2.695301841746248,
+            "z": 0
+          },
           "textHeight": 0.125,
           "text": "Project Title",
           "rotation": 90,
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.57354680961919,
+            "y": 3.15625,
+            "z": 0
+          },
           "prompt": "Project Title Line 1",
           "tag": "PROJECTTITLE1",
           "invisible": false,
@@ -840,12 +875,19 @@
           "handle": "E49",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 15.57310916713996,
-          "y": 1.590448017116665,
-          "z": 0,
+          "startPoint": {
+            "x": 15.57310916713996,
+            "y": 1.590448017116665,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "XXX-XXX",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.85698109756288,
+            "y": 1.590448017116665,
+            "z": 0
+          },
           "prompt": "Project No.",
           "tag": "PROJECTNO",
           "invisible": false,
@@ -860,12 +902,19 @@
           "handle": "E4A",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 15.89403014930068,
-          "y": 1.191807083027317,
-          "z": 0,
+          "startPoint": {
+            "x": 15.89403014930068,
+            "y": 1.191807083027317,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "XX/XX/XX",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 16.19248257085593,
+            "y": 1.191807083027317,
+            "z": 0
+          },
           "prompt": "Date?",
           "tag": "DATE",
           "invisible": false,
@@ -880,12 +929,19 @@
           "handle": "E4B",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 15.43644999923252,
-          "y": 1.191807083027317,
-          "z": 0,
+          "startPoint": {
+            "x": 15.43644999923252,
+            "y": 1.191807083027317,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "XXX",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.56748257085599,
+            "y": 1.191807083027317,
+            "z": 0
+          },
           "prompt": "Drawn By?",
           "tag": "DRAWNBY",
           "invisible": false,
@@ -900,12 +956,19 @@
           "handle": "E4C",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 15.56916140859481,
-          "y": 0.8160405170521904,
-          "z": 0,
+          "startPoint": {
+            "x": 15.56916140859481,
+            "y": 0.8160405170521904,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "See Sheet",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.875,
+            "y": 0.8160405170521904,
+            "z": 0
+          },
           "prompt": "Scale?",
           "tag": "SCALE",
           "invisible": false,
@@ -920,12 +983,19 @@
           "handle": "E4D",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 15.43835266030013,
-          "y": 0.1431021352662505,
-          "z": 0,
+          "startPoint": {
+            "x": 15.43835266030013,
+            "y": 0.1431021352662505,
+            "z": 0
+          },
           "textHeight": 0.375,
           "text": "X-X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.875,
+            "y": 0.1431021352662505,
+            "z": 0
+          },
           "prompt": "Sheet Number?",
           "tag": "SHEETNO",
           "invisible": false,
@@ -958,13 +1028,20 @@
           "handle": "E4F",
           "ownerHandle": "E1C",
           "layer": "FG-Note",
-          "x": 16.43136960442813,
-          "y": 2.748763642564802,
-          "z": 0,
+          "startPoint": {
+            "x": 16.43136960442813,
+            "y": 2.748763642564802,
+            "z": 0
+          },
           "textHeight": 0.125,
           "text": "NO NAME",
           "rotation": 90,
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 16.43136960442813,
+            "y": 3.15625,
+            "z": 0
+          },
           "prompt": "Sheet Title?",
           "tag": "SHEETTITLE",
           "invisible": false,
@@ -6087,12 +6164,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": -0.1201923076923079,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": -0.1201923076923079,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": -0.0733173076923079,
+            "z": 0
+          },
           "prompt": "Sheet Number?",
           "tag": "SHEETNO",
           "invisible": false,
@@ -6110,12 +6194,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": 0.0264423076923075,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": 0.0264423076923075,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": 0.0733173076923075,
+            "z": 0
+          },
           "prompt": "Detail Number?",
           "tag": "DETNO",
           "invisible": false,
@@ -6211,12 +6302,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": -0.1201923076923079,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": -0.1201923076923079,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": -0.0733173076923079,
+            "z": 0
+          },
           "prompt": "Sheet Number?",
           "tag": "SHEETNO",
           "invisible": false,
@@ -6234,12 +6332,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": 0.0264423076923075,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": 0.0264423076923075,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": 0.0733173076923075,
+            "z": 0
+          },
           "prompt": "Detail Number?",
           "tag": "DETNO",
           "invisible": false,
@@ -6335,12 +6440,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": -0.1201923076923079,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": -0.1201923076923079,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": -0.0733173076923079,
+            "z": 0
+          },
           "prompt": "Sheet Number?",
           "tag": "SHEETNO",
           "invisible": false,
@@ -6358,12 +6470,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": 0.0264423076923075,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": 0.0264423076923075,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": 0.0733173076923075,
+            "z": 0
+          },
           "prompt": "Detail Number?",
           "tag": "DETNO",
           "invisible": false,
@@ -6459,12 +6578,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": -0.1201923076923079,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": -0.1201923076923079,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": -0.0733173076923079,
+            "z": 0
+          },
           "prompt": "Sheet Number?",
           "tag": "SHEETNO",
           "invisible": false,
@@ -6482,12 +6608,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": 0.0264423076923075,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": 0.0264423076923075,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": 0.0733173076923075,
+            "z": 0
+          },
           "prompt": "Detail Number?",
           "tag": "DETNO",
           "invisible": false,
@@ -7105,13 +7238,20 @@
           "handle": "2302",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 15.97514981098344,
-          "y": 2.753495907230559,
-          "z": 0,
+          "startPoint": {
+            "x": 15.97514981098344,
+            "y": 2.753495907230559,
+            "z": 0
+          },
           "textHeight": 0.125,
           "text": "City, State",
           "rotation": 90,
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.97514981098344,
+            "y": 3.15625,
+            "z": 0
+          },
           "prompt": "Project Loction",
           "tag": "PROJECTLOCATION",
           "invisible": false,
@@ -7126,13 +7266,20 @@
           "handle": "2303",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 15.77434831030132,
-          "y": 2.695301841746248,
-          "z": 0,
+          "startPoint": {
+            "x": 15.77434831030132,
+            "y": 2.695301841746248,
+            "z": 0
+          },
           "textHeight": 0.125,
           "text": "Project Title",
           "rotation": 90,
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.77434831030132,
+            "y": 3.15625,
+            "z": 0
+          },
           "prompt": "Project Title Line 2",
           "tag": "PROJECTTITLE2",
           "invisible": false,
@@ -7147,13 +7294,20 @@
           "handle": "2304",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 15.57354680961919,
-          "y": 2.695301841746248,
-          "z": 0,
+          "startPoint": {
+            "x": 15.57354680961919,
+            "y": 2.695301841746248,
+            "z": 0
+          },
           "textHeight": 0.125,
           "text": "Project Title",
           "rotation": 90,
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.57354680961919,
+            "y": 3.15625,
+            "z": 0
+          },
           "prompt": "Project Title Line 1",
           "tag": "PROJECTTITLE1",
           "invisible": false,
@@ -7168,12 +7322,19 @@
           "handle": "2305",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 15.57310916713996,
-          "y": 1.590448017116665,
-          "z": 0,
+          "startPoint": {
+            "x": 15.57310916713996,
+            "y": 1.590448017116665,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "XXX-XXX",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.85698109756288,
+            "y": 1.590448017116665,
+            "z": 0
+          },
           "prompt": "Project No.",
           "tag": "PROJECTNO",
           "invisible": false,
@@ -7188,12 +7349,19 @@
           "handle": "2306",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 15.89403014930068,
-          "y": 1.191807083027317,
-          "z": 0,
+          "startPoint": {
+            "x": 15.89403014930068,
+            "y": 1.191807083027317,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "XX/XX/XX",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 16.19248257085593,
+            "y": 1.191807083027317,
+            "z": 0
+          },
           "prompt": "Date?",
           "tag": "DATE",
           "invisible": false,
@@ -7208,12 +7376,19 @@
           "handle": "2307",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 15.43644999923252,
-          "y": 1.191807083027317,
-          "z": 0,
+          "startPoint": {
+            "x": 15.43644999923252,
+            "y": 1.191807083027317,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "XXX",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.56748257085599,
+            "y": 1.191807083027317,
+            "z": 0
+          },
           "prompt": "Drawn By?",
           "tag": "DRAWNBY",
           "invisible": false,
@@ -7228,12 +7403,19 @@
           "handle": "2308",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 15.56916140859481,
-          "y": 0.8160405170521904,
-          "z": 0,
+          "startPoint": {
+            "x": 15.56916140859481,
+            "y": 0.8160405170521904,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "See Sheet",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.875,
+            "y": 0.8160405170521904,
+            "z": 0
+          },
           "prompt": "Scale?",
           "tag": "SCALE",
           "invisible": false,
@@ -7248,12 +7430,19 @@
           "handle": "2309",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 15.43835266030013,
-          "y": 0.1431021352662505,
-          "z": 0,
+          "startPoint": {
+            "x": 15.43835266030013,
+            "y": 0.1431021352662505,
+            "z": 0
+          },
           "textHeight": 0.375,
           "text": "X-X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 15.875,
+            "y": 0.1431021352662505,
+            "z": 0
+          },
           "prompt": "Sheet Number?",
           "tag": "SHEETNO",
           "invisible": false,
@@ -7286,13 +7475,20 @@
           "handle": "230B",
           "ownerHandle": "22DF",
           "layer": "FG-Note",
-          "x": 16.43136960442813,
-          "y": 2.748763642564802,
-          "z": 0,
+          "startPoint": {
+            "x": 16.43136960442813,
+            "y": 2.748763642564802,
+            "z": 0
+          },
           "textHeight": 0.125,
           "text": "NO NAME",
           "rotation": 90,
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 16.43136960442813,
+            "y": 3.15625,
+            "z": 0
+          },
           "prompt": "Sheet Title?",
           "tag": "SHEETTITLE",
           "invisible": false,
@@ -8150,12 +8346,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": -0.1201923076923079,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": -0.1201923076923079,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": -0.0733173076923079,
+            "z": 0
+          },
           "prompt": "Sheet Number?",
           "tag": "SHEETNO",
           "invisible": false,
@@ -8173,12 +8376,19 @@
           "layer": "0",
           "colorIndex": 1,
           "color": 16711680,
-          "x": -0.0265625,
-          "y": 0.0264423076923075,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0265625,
+            "y": 0.0264423076923075,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "X",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0,
+            "y": 0.0733173076923075,
+            "z": 0
+          },
           "prompt": "Detail Number?",
           "tag": "DETNO",
           "invisible": false,
@@ -8353,12 +8563,19 @@
           "handle": "31BF",
           "ownerHandle": "31B5",
           "layer": "0",
-          "x": 0.1463165075034089,
-          "y": -0.578024993810594,
-          "z": 0,
+          "startPoint": {
+            "x": 0.1463165075034089,
+            "y": -0.578024993810594,
+            "z": 0
+          },
           "textHeight": 0.3125,
           "text": "XX",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0.4374999999999983,
+            "y": -0.421774993810594,
+            "z": 0
+          },
           "prompt": "Section Number?",
           "tag": "SECTIONNUMBER",
           "invisible": false,
@@ -8374,12 +8591,19 @@
           "handle": "31C0",
           "ownerHandle": "31B5",
           "layer": "0",
-          "x": 2.308115684938186,
-          "y": -0.3811777376743812,
-          "z": 0,
+          "startPoint": {
+            "x": 2.308115684938186,
+            "y": -0.3811777376743812,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "",
           "horizontalJustification": 2,
+          "endPoint": {
+            "x": 2.308115684938186,
+            "y": -0.3811777376743812,
+            "z": 0
+          },
           "prompt": "Architectural Reference?",
           "tag": "ARCHREF",
           "invisible": false,
@@ -8394,12 +8618,19 @@
           "handle": "31C1",
           "ownerHandle": "31B5",
           "layer": "0",
-          "x": 2.308115684938185,
-          "y": -0.5671272951337798,
-          "z": 0,
+          "startPoint": {
+            "x": 2.308115684938185,
+            "y": -0.5671272951337798,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "",
           "horizontalJustification": 2,
+          "endPoint": {
+            "x": 2.308115684938185,
+            "y": -0.5671272951337798,
+            "z": 0
+          },
           "prompt": "Scale?",
           "tag": "SCALE",
           "invisible": false,
@@ -8555,12 +8786,19 @@
           "handle": "320B",
           "ownerHandle": "3201",
           "layer": "0",
-          "x": 0.1463165075034089,
-          "y": -0.578024993810594,
-          "z": 0,
+          "startPoint": {
+            "x": 0.1463165075034089,
+            "y": -0.578024993810594,
+            "z": 0
+          },
           "textHeight": 0.3125,
           "text": "XX",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0.4374999999999983,
+            "y": -0.421774993810594,
+            "z": 0
+          },
           "prompt": "Detail Number?",
           "tag": "DETAILNUMBER",
           "invisible": false,
@@ -8576,12 +8814,19 @@
           "handle": "320C",
           "ownerHandle": "3201",
           "layer": "0",
-          "x": 2.308115684938186,
-          "y": -0.3811777376743812,
-          "z": 0,
+          "startPoint": {
+            "x": 2.308115684938186,
+            "y": -0.3811777376743812,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "",
           "horizontalJustification": 2,
+          "endPoint": {
+            "x": 2.308115684938186,
+            "y": -0.3811777376743812,
+            "z": 0
+          },
           "prompt": "Architectural Reference?",
           "tag": "ARCHREF",
           "invisible": false,
@@ -8596,12 +8841,19 @@
           "handle": "320D",
           "ownerHandle": "3201",
           "layer": "0",
-          "x": 2.308115684938185,
-          "y": -0.5671272951337798,
-          "z": 0,
+          "startPoint": {
+            "x": 2.308115684938185,
+            "y": -0.5671272951337798,
+            "z": 0
+          },
           "textHeight": 0.09375,
           "text": "",
           "horizontalJustification": 2,
+          "endPoint": {
+            "x": 2.308115684938185,
+            "y": -0.5671272951337798,
+            "z": 0
+          },
           "prompt": "Scale?",
           "tag": "SCALE",
           "invisible": false,
@@ -8863,12 +9115,19 @@
           "handle": "34ED",
           "ownerHandle": "34EA",
           "layer": "0",
-          "x": -0.0071161210463473,
-          "y": -0.0617968433486147,
-          "z": 0,
+          "startPoint": {
+            "x": -0.0071161210463473,
+            "y": -0.0617968433486147,
+            "z": 0
+          },
           "textHeight": 0.1,
           "text": "",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": -0.0071161210463473,
+            "y": -0.0617968433486147,
+            "z": 0
+          },
           "prompt": "HOW MANY?",
           "tag": "QTY",
           "invisible": false,
@@ -41327,12 +41586,19 @@
           "handle": "5AEA",
           "ownerHandle": "5AE5",
           "layer": "0",
-          "x": 0.0450951536329658,
-          "y": 0.1126624729523638,
-          "z": 0,
+          "startPoint": {
+            "x": 0.0450951536329658,
+            "y": 0.1126624729523638,
+            "z": 0
+          },
           "textHeight": 0.1,
           "text": "",
           "horizontalJustification": 2,
+          "endPoint": {
+            "x": 0.0450951536329658,
+            "y": 0.1126624729523638,
+            "z": 0
+          },
           "prompt": "HOW HIGH?",
           "tag": "HIGH",
           "invisible": false,
@@ -41347,12 +41613,19 @@
           "handle": "5AEB",
           "ownerHandle": "5AE5",
           "layer": "0",
-          "x": 0.0323380282919095,
-          "y": -0.2252170611912008,
-          "z": 0,
+          "startPoint": {
+            "x": 0.0323380282919095,
+            "y": -0.2252170611912008,
+            "z": 0
+          },
           "textHeight": 0.1,
           "text": "",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0.0323380282919095,
+            "y": -0.2252170611912008,
+            "z": 0
+          },
           "prompt": "HOW MANY?",
           "tag": "QTY",
           "invisible": false,
@@ -41443,12 +41716,19 @@
           "handle": "5AF2",
           "ownerHandle": "5AED",
           "layer": "0",
-          "x": 0.0281863108945473,
-          "y": 0.1182977636045694,
-          "z": 0,
+          "startPoint": {
+            "x": 0.0281863108945473,
+            "y": 0.1182977636045694,
+            "z": 0
+          },
           "textHeight": 0.1,
           "text": "",
           "horizontalJustification": 2,
+          "endPoint": {
+            "x": 0.0281863108945473,
+            "y": 0.1182977636045694,
+            "z": 0
+          },
           "prompt": "HOW DEEP?",
           "tag": "DEEP",
           "invisible": false,
@@ -41463,12 +41743,19 @@
           "handle": "5AF3",
           "ownerHandle": "5AED",
           "layer": "0",
-          "x": 0.0154291855534909,
-          "y": -0.2195817705389951,
-          "z": 0,
+          "startPoint": {
+            "x": 0.0154291855534909,
+            "y": -0.2195817705389951,
+            "z": 0
+          },
           "textHeight": 0.1,
           "text": "",
           "horizontalJustification": 1,
+          "endPoint": {
+            "x": 0.0154291855534909,
+            "y": -0.2195817705389951,
+            "z": 0
+          },
           "prompt": "HOW MANY?",
           "tag": "QTY",
           "invisible": false,
@@ -60560,9 +60847,11 @@
           "handle": "99ED",
           "ownerHandle": "99C2",
           "layer": "A-ANNO-NOTES",
-          "x": 38.32749879713279,
-          "y": 3.796602387892264,
-          "z": 0,
+          "startPoint": {
+            "x": 38.32749879713279,
+            "y": 3.796602387892264,
+            "z": 0
+          },
           "textHeight": 0.094,
           "text": "",
           "rotation": 90,
@@ -60580,9 +60869,11 @@
           "handle": "99EE",
           "ownerHandle": "99C2",
           "layer": "A-ANNO-NOTES",
-          "x": 38.5721660417183,
-          "y": 3.79871366928215,
-          "z": 0,
+          "startPoint": {
+            "x": 38.5721660417183,
+            "y": 3.79871366928215,
+            "z": 0
+          },
           "textHeight": 0.094,
           "text": "",
           "rotation": 90,
@@ -60600,9 +60891,11 @@
           "handle": "99EF",
           "ownerHandle": "99C2",
           "layer": "A-ANNO-NOTES",
-          "x": 38.82145410231667,
-          "y": 3.798709520754627,
-          "z": 0,
+          "startPoint": {
+            "x": 38.82145410231667,
+            "y": 3.798709520754627,
+            "z": 0
+          },
           "textHeight": 0.094,
           "text": "",
           "rotation": 90,
@@ -60620,9 +60913,11 @@
           "handle": "99F0",
           "ownerHandle": "99C2",
           "layer": "A-ANNO-NOTES",
-          "x": 39.07011812657281,
-          "y": 3.792844779312176,
-          "z": 0,
+          "startPoint": {
+            "x": 39.07011812657281,
+            "y": 3.792844779312176,
+            "z": 0
+          },
           "textHeight": 0.094,
           "text": "",
           "rotation": 90,
@@ -60640,9 +60935,11 @@
           "handle": "99F1",
           "ownerHandle": "99C2",
           "layer": "A-ANNO-NOTES",
-          "x": 39.31959671750038,
-          "y": 3.792844779312176,
-          "z": 0,
+          "startPoint": {
+            "x": 39.31959671750038,
+            "y": 3.792844779312176,
+            "z": 0
+          },
           "textHeight": 0.094,
           "text": "Date",
           "rotation": 90,
@@ -60660,9 +60957,11 @@
           "handle": "99F2",
           "ownerHandle": "99C2",
           "layer": "A-ANNO-NOTES",
-          "x": 39.32118608110299,
-          "y": 5.523692154493588,
-          "z": 0,
+          "startPoint": {
+            "x": 39.32118608110299,
+            "y": 5.523692154493588,
+            "z": 0
+          },
           "textHeight": 0.094,
           "text": "",
           "rotation": 90,


### PR DESCRIPTION
Make it more consistent to TEXT and parse 10,20,30 to "startPoint" object property (instead of x,y,z property) and also support "endPoint" for groups 11,21,31.