### PR TITLE
Fix use of `checkCommonEntityProperties` in 3dface.js

### DIFF
--- a/lib/entities/3dface.js
+++ b/lib/entities/3dface.js
@@ -23,7 +23,7 @@ EntityParser.prototype.parseEntity = function(scanner, curr) {
                 curr = scanner.lastReadGroup;
                 break;
             default:
-                checkCommonEntityProperties(entity);
+                helpers.checkCommonEntityProperties(entity, curr);
                 break;
         }
         curr = scanner.next();


### PR DESCRIPTION
`checkCommonEntityProperties` is part of the helpers module, it's not global.

`checkCommonEntityProperties` needs the "current group" as the second argument.