### PR TITLE
Replace 'require' with 'import'.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2655,7 +2655,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3070,7 +3071,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3126,6 +3128,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3169,12 +3172,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/DxfParser.js
+++ b/src/DxfParser.js
@@ -18,7 +18,7 @@ import Spline from './entities/spline';
 import Text from './entities/text';
 //import Vertex from './entities/';
 
-var log = require('loglevel');
+import log from 'loglevel';
 
 //log.setLevel('trace');
 //log.setLevel('debug');


### PR DESCRIPTION
The require in the es6 module was breaking rollup for me.

Changing it to import seems to work nicely for both rollup and webpack.