### PR TITLE
Revert DxfParser import in tests, fixes #79

### DIFF
--- a/test/DxfParser.test.js
+++ b/test/DxfParser.test.js
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import parse,{DxfParser} from '../dist/index.js';
+import DxfParser from '../dist/index.js';
 import should from 'should';
 import approvals from 'approvals';
 
@@ -180,8 +180,9 @@ function verifyDxf(sourceFilePath) {
 	var sourceDirectory = path.dirname(sourceFilePath);
 
 	var file = fs.readFileSync(sourceFilePath, 'utf8');
-
-	var dxf = parse(file);
+	
+	var parser = new DxfParser();
+	var dxf = parser.parse(file);
 
 	approvals.verifyAsJSON(sourceDirectory, baseName, dxf);
 }


### PR DESCRIPTION
Fixes running tests after build.

- #79 

```
  Scanner
    .hasNext()
      ✓ should return false when the array is empty
      ✓ should return false when the array has length 1
      ✓ should return true when the array has length 2
      ✓ should return false when the array has length 4 and pointer is on the last element
      ✓ should return true when the array has length 4 and pointer is on the second-to-last element
    .next()
      ✓ should throw an error when the array is empty
      ✓ should throw an error when the array has only 1 element
      ✓ should throw an error when next is called and eof has already been read
      ✓ should return the 1st and 2nd index as the code and value respectively
      ✓ should set _eof to true when EOF code-value pair is read
      ✓ should increment the pointer by 2
    .isEOF()
      ✓ should be true when _eof is true

  Parser
    ✓ should parse the dxf header variables into an object
    ✓ should parse the tables section without error
    ✓ should parse the dxf layers
    ✓ should parse the dxf ltype table
    ✓ should parse the dxf viewPort table
    ✓ should parse a complex BLOCKS section (111ms)
    ✓ should parse a simple BLOCKS section
    ✓ should parse POLYLINES
    ✓ should parse ELLIPSE entities
    ✓ should parse SPLINE entities
    ✓ should parse EXTENDED DATA
    ✓ should parse SPLINE entities that are like arcs and circles
    ✓ should parse ARC entities (1)
    ✓ should parse MTEXT entities


  26 passing (183ms)
```