### PR TITLE
Export true ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ out.json
 *.actual.json
 .vscode/
 *.received.*
-dist/
+commonjs/*.js
+esm/
 *.tgz
 *.lock

--- a/README.md
+++ b/README.md
@@ -11,35 +11,20 @@ Also, keep an eye on [three-dxf](https://github.com/gdsestimating/three-dxf), a 
 npm install dxf-parser
 ```
 
-Browsers -- As of 0.1.3 standalone browserify version is in the dist/ folder. Copy it out of the install directory or just download it from the GitHub repo directly. We may evetually publish this to bower, but the build environment needs a little work first.
+Browsers -- As of 0.1.3 standalone browserify version is in the commonjs/ folder. Copy it out of the install directory or just download it from the GitHub repo directly. We may evetually publish this to bower, but the build environment needs a little work first.
 
 #### Usage
 
 ``` js
-import parse, { DxfParser } from 'dxf-parser';
+import DxfParser from 'dxf-parser';
 
 // Grab fileText in node.js or browser
 const fileText = ...;
 
 const parser = new DxfParser();
 try {
-    const dxf = parser.parseSync(fileText);
-}catch(err) {
-    return console.error(err.stack);
-}
-```
-
-or
-
-```ts
-// Grab fileText in node.js or browser
-import parse from 'dxf-parser';
-
-const fileText = ...;
-
-try {
-    const dxf = parse(fileText);
-}catch(err) {
+    const dxf = parser.parse(fileText);
+} catch(err) {
     return console.error(err.stack);
 }
 ```

--- a/commonjs/package.json
+++ b/commonjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,14 @@
 	"name": "dxf-parser",
 	"version": "1.1.2",
 	"description": "Parse dxf files into a readable, logical js object.",
-	"main": "./dist/dxf-parser.js",
-	"module": "./dist/index.js",
-	"types": "./dist/index.d.ts",
+	"type": "module",
+	"main": "./commonjs/index.js",
+	"module": "./esm/index.js",
+	"exports": {
+		"import": "./esm/index.js",
+		"require": "./commonjs/index.js"
+	},
+	"types": "./esm/index.d.ts",
 	"scripts": {
 		"test": "mocha --require @babel/register test",
 		"dev": "tsc -w & webpack --mode development",
@@ -46,7 +51,8 @@
 		"reader"
 	],
 	"files": [
-		"dist",
+		"commonjs",
+		"esm",
 		"src"
 	]
 }

--- a/samples/browser/index.html
+++ b/samples/browser/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<title>Dxf-Parser - Browser Sample</title>
 		
-		<script src="../../dist/dxf-parser.js"></script>
+		<script src="../../commonjs/index.js"></script>
 	</head>
 	<body>
 		<input id="file-field" type="file"/>

--- a/samples/node/parse-stream.js
+++ b/samples/node/parse-stream.js
@@ -1,8 +1,8 @@
-var DxfParser = require('../../dist/dxf-parser');
-var fs = require('fs');
-var path = require('path');
+import DxfParser from '../../esm/index.js'
+import fs from 'fs'
+import path from 'path'
 
-console.log(DxfParser);
+const __dirname = path.dirname(new URL(import.meta.url).pathname)
 
 var DXF_FILE_PATH = path.join(__dirname, '..', 'data', 'api-cw750-details.dxf');
 var OUTPUT_FILE_NAME = "out.json";
@@ -10,8 +10,6 @@ var OUTPUT_FILE_NAME = "out.json";
 var fileStream = fs.createReadStream(DXF_FILE_PATH, { encoding: 'utf8' });
 
 var parser = new DxfParser();
-parser.parseStream(fileStream, function(err, dxf) {
-    if(err) return console.error(err.stack);
-    fs.writeFileSync(OUTPUT_FILE_NAME, JSON.stringify(dxf, null, 3));
-    console.log('Done writing output to ' + OUTPUT_FILE_NAME);
-});
+const dxf = await parser.parseStream(fileStream);
+fs.writeFileSync(OUTPUT_FILE_NAME, JSON.stringify(dxf, null, 3));
+console.log('Done writing output to ' + OUTPUT_FILE_NAME);

--- a/samples/node/parse-sync.js
+++ b/samples/node/parse-sync.js
@@ -1,6 +1,8 @@
-var DxfParser = require('../../dist/dxf-parser');
-var fs = require('fs');
-var path = require('path');
+import DxfParser from '../../esm/index.js'
+import fs from 'fs'
+import path from 'path'
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname)
 
 var DXF_FILE_PATH = path.join(__dirname, '..', 'data', 'api-cw750-details.dxf');
 var OUTPUT_FILE_NAME = "out.json";

--- a/src/DxfParser.ts
+++ b/src/DxfParser.ts
@@ -1,26 +1,26 @@
 import { Readable } from 'stream';
-import DxfArrayScanner, { IGroup } from './DxfArrayScanner';
-import AUTO_CAD_COLOR_INDEX from './AutoCadColorIndex';
+import DxfArrayScanner, { IGroup } from './DxfArrayScanner.js';
+import AUTO_CAD_COLOR_INDEX from './AutoCadColorIndex.js';
 
-import Face from './entities/3dface';
-import Arc from './entities/arc';
-import AttDef from './entities/attdef';
-import Circle from './entities/circle';
-import Dimension from './entities/dimension';
-import Ellipse from './entities/ellipse';
-import Insert from './entities/insert';
-import Line from './entities/line';
-import LWPolyline from './entities/lwpolyline';
-import MText from './entities/mtext';
-import Point from './entities/point';
-import Polyline from './entities/polyline';
-import Solid from './entities/solid';
-import Spline from './entities/spline';
-import Text from './entities/text';
-//import Vertex from './entities/';
+import Face from './entities/3dface.js';
+import Arc from './entities/arc.js';
+import AttDef from './entities/attdef.js';
+import Circle from './entities/circle.js';
+import Dimension from './entities/dimension.js';
+import Ellipse from './entities/ellipse.js';
+import Insert from './entities/insert.js';
+import Line from './entities/line.js';
+import LWPolyline from './entities/lwpolyline.js';
+import MText from './entities/mtext.js';
+import Point from './entities/point.js';
+import Polyline from './entities/polyline.js';
+import Solid from './entities/solid.js';
+import Spline from './entities/spline.js';
+import Text from './entities/text.js';
+//import Vertex from './entities/.js';
 
 import log from 'loglevel';
-import IGeometry, { EntityName, IEntity, IPoint } from './entities/geomtry';
+import IGeometry, { EntityName, IEntity, IPoint } from './entities/geomtry.js';
 
 //log.setLevel('trace');
 //log.setLevel('debug');

--- a/src/ParseHelpers.ts
+++ b/src/ParseHelpers.ts
@@ -1,6 +1,6 @@
-import AUTO_CAD_COLOR_INDEX from './AutoCadColorIndex';
-import DxfArrayScanner, { IGroup } from './DxfArrayScanner';
-import { IEntity, IPoint } from './entities/geomtry';
+import AUTO_CAD_COLOR_INDEX from './AutoCadColorIndex.js';
+import DxfArrayScanner, { IGroup } from './DxfArrayScanner.js';
+import { IEntity, IPoint } from './entities/geomtry.js';
 
 /**
  * Returns the truecolor value of the given AutoCad color index value

--- a/src/entities/3dface.ts
+++ b/src/entities/3dface.ts
@@ -1,8 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface I3DfaceEntity extends IEntity {
 	shape: boolean;

--- a/src/entities/arc.ts
+++ b/src/entities/arc.ts
@@ -1,8 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IArcEntity extends IEntity {
 	center: IPoint;

--- a/src/entities/attdef.ts
+++ b/src/entities/attdef.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IAttdefEntity extends IEntity {
 	scale: number;

--- a/src/entities/circle.ts
+++ b/src/entities/circle.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface ICircleEntity extends IEntity {
 	center: IPoint;

--- a/src/entities/dimension.ts
+++ b/src/entities/dimension.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IDimensionEntity extends IEntity{
 	block: string;

--- a/src/entities/ellipse.ts
+++ b/src/entities/ellipse.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IEllipseEntity extends IEntity {
 	center: IPoint;

--- a/src/entities/geomtry.ts
+++ b/src/entities/geomtry.ts
@@ -1,4 +1,4 @@
-import DxfArrayScanner, { IGroup } from "../DxfArrayScanner";
+import DxfArrayScanner, { IGroup } from "../DxfArrayScanner.js";
 
 export interface IPoint {
 	x: number;

--- a/src/entities/insert.ts
+++ b/src/entities/insert.ts
@@ -1,6 +1,6 @@
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IInsertEntity extends IEntity {
 	name: string;

--- a/src/entities/line.ts
+++ b/src/entities/line.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface ILineEntity extends IEntity{
 	vertices: IPoint[];

--- a/src/entities/lwpolyline.ts
+++ b/src/entities/lwpolyline.ts
@@ -1,6 +1,6 @@
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IVertex extends IPoint{
 	startWidth: number;

--- a/src/entities/mtext.ts
+++ b/src/entities/mtext.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IMtextEntity extends IEntity {
 	text: string;

--- a/src/entities/point.ts
+++ b/src/entities/point.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IPointEntity extends IEntity{
 	position: IPoint;

--- a/src/entities/polyline.ts
+++ b/src/entities/polyline.ts
@@ -1,8 +1,7 @@
-
-import * as helpers from '../ParseHelpers'
-import VertexParser, { IVertexEntity } from './vertex';
-import IGeometry, { IEntity, IPoint } from './geomtry';
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
+import * as helpers from '../ParseHelpers.js';
+import VertexParser, { IVertexEntity } from './vertex.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
 
 export interface IPolylineEntity extends IEntity {
 	vertices: IVertexEntity[];

--- a/src/entities/solid.ts
+++ b/src/entities/solid.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface ISolidEntity extends IEntity {
 	points: IPoint[];

--- a/src/entities/spline.ts
+++ b/src/entities/spline.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface ISplineEntity extends IEntity {
 	controlPoints?: IPoint[];

--- a/src/entities/text.ts
+++ b/src/entities/text.ts
@@ -1,7 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface ITextEntity extends IEntity {
 	startPoint: IPoint;

--- a/src/entities/vertex.ts
+++ b/src/entities/vertex.ts
@@ -1,8 +1,6 @@
-
-import DxfArrayScanner, { IGroup } from '../DxfArrayScanner';
-import * as helpers from '../ParseHelpers'
-
-import IGeometry, { IEntity, IPoint } from './geomtry';
+import DxfArrayScanner, { IGroup } from '../DxfArrayScanner.js';
+import * as helpers from '../ParseHelpers.js';
+import IGeometry, { IEntity, IPoint } from './geomtry.js';
 
 export interface IVertexEntity extends IEntity, IPoint{
 	bulge: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,19 @@
-import DxfParser from './DxfParser';
-export { default as DxfParser } from './DxfParser';
-export { IDxf, IBlock, ILayerTypesTable, ILayersTable, ITables, IViewPortTable, IBaseTable, ILayer, ILayerTableDefinition, ILineType, ILineTypeTableDefinition, ITable, ITableDefinitions, IViewPort, IViewPortTableDefinition } from './DxfParser';
-export { IEntity, IPoint } from './entities/geomtry';
-export { I3DfaceEntity } from './entities/3dface';
-export { IArcEntity } from './entities/arc';
-export { IAttdefEntity } from './entities/attdef';
-export { ICircleEntity } from './entities/circle';
-export { IDimensionEntity } from './entities/dimension';
-export { IEllipseEntity } from './entities/ellipse';
-export { IInsertEntity } from './entities/insert';
-export { ILineEntity } from './entities/line';
-export { ILwpolylineEntity } from './entities/lwpolyline';
-export { IMtextEntity } from './entities/mtext';
-export { IPointEntity } from './entities/point';
-export { IPolylineEntity } from './entities/polyline';
-export { ISolidEntity } from './entities/solid';
-export { ISplineEntity } from './entities/spline';
-export { ITextEntity } from './entities/text';
-export { IVertexEntity } from './entities/vertex';
-
-export default function parse(source: string) {
-	return new DxfParser().parse(source);
-}
+export { default, default as DxfParser } from './DxfParser.js';
+export { IDxf, IBlock, ILayerTypesTable, ILayersTable, ITables, IViewPortTable, IBaseTable, ILayer, ILayerTableDefinition, ILineType, ILineTypeTableDefinition, ITable, ITableDefinitions, IViewPort, IViewPortTableDefinition } from './DxfParser.js';
+export { IEntity, IPoint } from './entities/geomtry.js';
+export { I3DfaceEntity } from './entities/3dface.js';
+export { IArcEntity } from './entities/arc.js';
+export { IAttdefEntity } from './entities/attdef.js';
+export { ICircleEntity } from './entities/circle.js';
+export { IDimensionEntity } from './entities/dimension.js';
+export { IEllipseEntity } from './entities/ellipse.js';
+export { IInsertEntity } from './entities/insert.js';
+export { ILineEntity } from './entities/line.js';
+export { ILwpolylineEntity } from './entities/lwpolyline.js';
+export { IMtextEntity } from './entities/mtext.js';
+export { IPointEntity } from './entities/point.js';
+export { IPolylineEntity } from './entities/polyline.js';
+export { ISolidEntity } from './entities/solid.js';
+export { ISplineEntity } from './entities/spline.js';
+export { ITextEntity } from './entities/text.js';
+export { IVertexEntity } from './entities/vertex.js';

--- a/test/DxfArrayScanner.test.js
+++ b/test/DxfArrayScanner.test.js
@@ -1,4 +1,4 @@
-import Scanner from '../dist/DxfArrayScanner.js';
+import Scanner from '../esm/DxfArrayScanner.js';
 import 'should';
 
 describe('Scanner', function() {

--- a/test/DxfParser.test.js
+++ b/test/DxfParser.test.js
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import DxfParser from '../dist/index.js';
+import DxfParser from '../esm/index.js';
 import should from 'should';
 import approvals from 'approvals';
 
@@ -20,6 +20,8 @@ approvals.configure({
 	failOnLineEndingDifferences: false,
 	stripBOM: true,
 });
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname)
 
 describe('Parser', function() {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
 		"strictNullChecks": true,
 		"noImplicitThis": true,
 		"rootDir": "./src",
-		"outDir": "./dist/",
+		"outDir": "./esm/",
 		"allowJs": false,
 		"allowUnreachableCode": false,
 		"allowUnusedLabels": false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,10 @@
-const path = require('path');
+import { resolve, dirname } from 'path';
 
-module.exports = {
-	entry: './dist/index.js',
+export default {
+	entry: './esm/index.js',
 	output: {
-		filename: 'dxf-parser.js',
-		path: path.resolve(__dirname, 'dist'),
+		filename: 'index.js',
+		path: resolve(dirname(new URL(import.meta.url).pathname), 'commonjs'),
 		library: {
 			name: 'DxfParser',
 			type: 'umd',


### PR DESCRIPTION
Option 2 from https://2ality.com/2019/10/hybrid-npm-packages.html.

Ran `npm test`, smoke-tested `samples/browser` and `samples/node`, integrated in my own TypeScript ESM project, no issues. Reverted https://github.com/gdsestimating/dxf-parser/pull/83, there's nothing wrong with default-exporting a class. Requires Node 13.2+ to build.

Published: https://www.npmjs.com/package/@alecmev/dxf-parser