### PR TITLE
MLeader: fix text height

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Support
 * VPort table
 * Text and some MTEXT
 * Some XData
+* Most MLeaders
 
 Does not yet support
 
 * 3DSolids
-* All types of Leaders
 * other less common objects and entities.
 
 ### Contributing

--- a/src/entities/mleader.ts
+++ b/src/entities/mleader.ts
@@ -60,7 +60,7 @@ interface IMLeaderContextData {
     textDirection: IPoint; // 13,23,33
     textRotation: number; // 42
     textWidth: number; // 43
-    // textHeight: number; // 44 - duplicate key in spec doc
+    textHeightAlt: number; // 44 - duplicate key in spec doc
     textLineSpacingFactor: number; // 45
     textLineSpacingStyle: number; // 170
     textColor: number; // 90
@@ -301,7 +301,7 @@ export default class MLeader implements IGeometry {
                         entity.contextData.textWidth = curr.value as number;
                         break;
                     case 44:
-                        entity.contextData.textHeight = curr.value as number;
+                        entity.contextData.textHeightAlt = curr.value as number;
                         break;
                     case 45:
                         entity.contextData.textLineSpacingFactor =

--- a/test/data/mleader.approved.txt
+++ b/test/data/mleader.approved.txt
@@ -101,7 +101,8 @@
           "z": 0
         },
         "textFlowDirection": 1,
-        "textHeight": 0,
+        "textHeight": 350,
+        "textHeightAlt": 0,
         "textLineSpacingFactor": 1,
         "textLineSpacingStyle": 1,
         "textLocation": {
@@ -250,7 +251,8 @@
           "z": 0
         },
         "textFlowDirection": 1,
-        "textHeight": 0,
+        "textHeight": 350,
+        "textHeightAlt": 0,
         "textLineSpacingFactor": 1,
         "textLineSpacingStyle": 1,
         "textLocation": {
@@ -384,7 +386,8 @@
           "z": 0
         },
         "textFlowDirection": 1,
-        "textHeight": 0,
+        "textHeight": 350,
+        "textHeightAlt": 0,
         "textLineSpacingFactor": 1,
         "textLineSpacingStyle": 1,
         "textLocation": {


### PR DESCRIPTION
The ADSK spec shows two values for textHeight; I (wrongly) assumed a dxf writer would use one or the other. This keeps both values. Good chance I'll run into some more of these over time as well...

Also updated `readme.md` to reflect MLeader support.

Not directly related, but here's a sample of drawing an MText based MLeader in a fashion that's similar to `three-dxf`.

<details>
<summary>threejs sample code</summary>

```TS

  function drawMLeader(entity: ILeaderEntity, data: any) {
    const group = new Object3D();

    const color = getColor(entity, data);

    const context = entity.contextData;

    if (context.hasMText) {
      const textMat = getMaterialForColour(color, "basic");

      const geometry = new TextGeometry(context.defaultTextContents, {
        font: font,
        height: 0,
        size: context.textHeight ?? context.textHeightAlt ?? 12,
      });

      const offset = new Vector3(
        0,
        -(context.textHeight ?? context.textHeightAlt ?? 12)
      );

      if (context.landingGap) {
        if (context.textDirection) {
        }
      }

      offset.x += context.landingGap ?? 0;

      geometry.translate(offset.x, offset.y, 0);

      const text = new THREE.Mesh(geometry, textMat);

      if (context.textLocation) {
        // Justifications already applied
        text.position.set(
          context.textLocation.x,
          context.textLocation.y,
          context.textLocation.z ?? 0
        );
      } else if (context.contentBasePosition) {
        // TODO Apply justifications
        text.position.set(
          context.contentBasePosition.x,
          context.contentBasePosition.y,
          context.contentBasePosition.z ?? 0
        );
      }

      group.add(text);
    } else if (context.hasBlock) {
      console.warn("Block leaders are not yet implemented");
      return null;
    }

    const lineMat = getMaterialForColour(color, "line");
    context.leaders.forEach((leader) => {
      leader.leaderLines.forEach((line) => {
        line.vertices.forEach((vArr) => {
          const arrLength = leader.hasSetLastLeaderLinePoint
            ? vArr.length + 1
            : vArr.length;

          const attr = new BufferAttribute(
            new Float32Array(arrLength * 3),
            3,
            false
          );
          vArr.forEach((v, i) => {
            attr.setXYZ(i, v.x, v.y, v.z);
          });
          if (leader.hasSetLastLeaderLinePoint) {
            attr.setXYZ(
              arrLength - 1,
              leader.lastLeaderLinePoint.x,
              leader.lastLeaderLinePoint.y,
              leader.lastLeaderLinePoint.z
            );
          }
          const buffer = new BufferGeometry();
          buffer.setAttribute("position", attr);
          var ls = new Line(buffer, lineMat);
          group.add(ls);
        });
      });
    });

    return group;
  }
```

</details>