### PR TITLE
ExtrusionThickness added to SOLID entity.

### DIFF
--- a/src/entities/solid.ts
+++ b/src/entities/solid.ts
@@ -5,7 +5,7 @@ import IGeometry, { IEntity, IPoint } from './geomtry.js';
 export interface ISolidEntity extends IEntity {
 	points: IPoint[];
 	extrusionDirection: IPoint;
-	extrusionDepth: number;
+	extrusionThickness: number;
 }
 
 export default class Solid implements IGeometry {
@@ -30,7 +30,7 @@ export default class Solid implements IGeometry {
 					entity.points[3] = helpers.parsePoint(scanner);
 					break;
 				case 39:
-					entity.extrusionDepth = curr.value;
+					entity.extrusionThickness = curr.value;
 					break;
 				case 210:
 					entity.extrusionDirection = helpers.parsePoint(scanner);


### PR DESCRIPTION
Hi there, 

I needed the extrusion thickness on the solid entity (since without it you've got no extrusion depth dimension). Autodesk spec lists under the 39 flag on a solid entity, so I've added to suit. 

I'm not usually a js/ts dev so bit out of my depth here. Hopefully it's all ok. Sorry, no tests.

Thanks,

Adam

